### PR TITLE
Fix/macaddress

### DIFF
--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -619,6 +619,8 @@ class Network(object):
             if is_netbox_42_plus:
                 if nic["mac"]:
                     self.update_interface_macs(interface, [nic["mac"]])
+                    # Refresh interface so future saves don't include stale primary MAC diffs
+                    interface = self.nb_net.interfaces.get(id=interface.id)
             elif nic["mac"] and nic["mac"] != interface.mac_address:
                 logging.info(
                     "Updating interface {interface} mac_address to: {mac}".format(

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -684,6 +684,15 @@ class Network(object):
                 # sync local IPs
                 for ip in nic["ip"]:
                     self.create_or_update_netbox_ip_on_interface(ip, interface)
+
+            if is_netbox_42_plus:
+                primary_obj = getattr(interface, "primary_mac_address", None)
+                if primary_obj and not isinstance(primary_obj, int):
+                    primary_id = getattr(primary_obj, "id", None)
+                    if primary_id is None and isinstance(primary_obj, dict):
+                        primary_id = primary_obj.get("id")
+                    if primary_id:
+                        interface.primary_mac_address = primary_id
             if nic_update > 0:
                 interface.save()
 


### PR DESCRIPTION
This pull request updates how network interface MAC addresses are managed in `netbox_agent/network.py` to improve compatibility with NetBox 4.2+ and streamline MAC address handling. The changes introduce a version check for NetBox 4.2, refactor how the object type is determined for MAC assignment, and ensure proper assignment and refreshing of primary MAC addresses.

**NetBox 4.2+ compatibility and MAC address management:**

* Introduced the `is_netbox_42_plus` variable to check if the connected NetBox instance is version 4.2 or newer, centralizing version logic for later use.
* Refactored the determination of `object_type` in `_update_interface_macs_new` to use `self.assigned_object_type` instead of checking for the existence of `virtual_machines`, making the logic more robust and explicit.

**Primary MAC address handling improvements:**

* For NetBox 4.2+, after updating interface MACs, the interface object is refreshed to avoid stale data and ensure future saves don't include outdated primary MAC diffs.
* Added logic to ensure that, for NetBox 4.2+, the `primary_mac_address` is always set to the correct ID, handling both object and dictionary forms.

**Code cleanup:**

* Removed redundant or outdated MAC address update logic for older NetBox versions, consolidating and simplifying the update flow. [[1]](diffhunk://#diff-d37a2e85b2951f5fdf56347f4cc124bfbfcaf5e900d7a096de98281edb35d480L605-L610) [[2]](diffhunk://#diff-d37a2e85b2951f5fdf56347f4cc124bfbfcaf5e900d7a096de98281edb35d480L623-L637)